### PR TITLE
fix: handle repository switch state during update auth errors

### DIFF
--- a/data/po/pt.po
+++ b/data/po/pt.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# Hugo Carvalho <hugokarvalho@hotmail.com>, 2024.
+# Hugo Carvalho <hugokarvalho@hotmail.com>, 2024, 2025.
 #
 #, fuzzy
 msgid ""
@@ -9,14 +9,15 @@ msgstr ""
 "Project-Id-Version: pardus-nvidia-installer\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-01-07 11:20+0300\n"
-"PO-Revision-Date: 2024-07-16 00:16+0100\n"
+"PO-Revision-Date: 2025-01-07 15:12+0000\n"
 "Last-Translator: Hugo Carvalho <hugokarvalho@hotmail.com>\n"
 "Language-Team: Portuguese <hugokarvalho@hotmail.com>\n"
 "Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.4.4\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.5\n"
 
 #: ui/ui.glade:11
 msgid "<span><b>Warning</b></span>"
@@ -59,6 +60,28 @@ msgid ""
 "href=\"https://github.com/pardus/pardus-nvidia-installer\"> Pardus Github </"
 "a>"
 msgstr ""
+"Esta aplicação é desenvolvida e mantida pela equipa do Pardus para facilitar "
+"a instalação do controlador gráfico da Nvidia. Os controladores são obtidos "
+"a partir dos repositórios oficiais do Pardus e da Nvidia.\n"
+"\n"
+"<b>Fonte e utilização dos controladores</b>\n"
+"Embora esta seja um aplicação oficial do Pardus, os controladores gráficos "
+"em si são desenvolvidos pela Nvidia Corporation. O Pardus fornece esta "
+"ferramenta de instalação como uma conveniência para os nossos utilizadores, "
+"mas os controladores continuam a ser propriedade intelectual da Nvidia "
+"Corporation.\n"
+"\n"
+"<b>Isenção de responsabilidade:</b>\n"
+"Tenha em atenção que, embora nos esforcemos por assegurar um processo de "
+"instalação sem problemas, o Pardus não pode garantir o desempenho ou a "
+"compatibilidade dos controladores Nvidia com todas as configurações de "
+"hardware. Os utilizadores instalam estes controladores por sua própria conta "
+"e risco.\n"
+"\n"
+"<b>Comunicação de problemas:</b>\n"
+"Pode comunicar quaisquer problemas ou preocupações através do nosso "
+"repositório GitHub: <a href=\"https://github.com/pardus/pardus-nvidia-"
+"installer\"> GitHub do Pardus </a>"
 
 #: ui/ui.glade:177
 msgid ""
@@ -136,12 +159,11 @@ msgstr "Operação concluída com sucesso"
 
 #: src/std_opr.py:86
 msgid "Auth or cancellation error"
-msgstr ""
+msgstr "Erro de autenticação ou cancelamento"
 
 #: src/std_opr.py:88
-#, fuzzy
 msgid "An error occured"
-msgstr "Ocorreu um erro."
+msgstr "Ocorreu um erro"
 
 #, fuzzy
 #~ msgid ""

--- a/src/std_opr.py
+++ b/src/std_opr.py
@@ -83,7 +83,12 @@ def on_process_stdext(pid, stat, self):
             self.ui_confirm_dialog.destroy()
         self.create_gpu_drivers()
     if stat == 15 or stat == 32256 or stat == 32512:
+        if self.apt_opr == "update":
+            self.ui_repo_switch.handler_block_by_func(self.on_nvidia_mirror_changed)  
+            self.ui_repo_switch.set_active(not self.ui_repo_switch.get_active())
+            self.ui_repo_switch.handler_unblock_by_func(self.on_nvidia_mirror_changed)  
         self.ui_status_progressbar.set_text(_("Auth or cancellation error"))
+
     else:
         self.ui_status_progressbar.set_text(_("An error occured"))
     self.ui_main_window.set_sensitive(True)


### PR DESCRIPTION
## Description

After pressing the Use nvidia repository toggle button, the value that should not change if you continue without entering the password on the authorization screen was changing.