### PR TITLE
nvidia-suspend and cuda source

### DIFF
--- a/data/po/pt.po
+++ b/data/po/pt.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# Hugo Carvalho <hugokarvalho@hotmail.com>, 2024.
+# Hugo Carvalho <hugokarvalho@hotmail.com>, 2024, 2025.
 #
 #, fuzzy
 msgid ""
@@ -9,14 +9,15 @@ msgstr ""
 "Project-Id-Version: pardus-nvidia-installer\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-01-07 11:20+0300\n"
-"PO-Revision-Date: 2024-07-16 00:16+0100\n"
+"PO-Revision-Date: 2025-01-07 15:12+0000\n"
 "Last-Translator: Hugo Carvalho <hugokarvalho@hotmail.com>\n"
 "Language-Team: Portuguese <hugokarvalho@hotmail.com>\n"
 "Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.4.4\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.5\n"
 
 #: ui/ui.glade:11
 msgid "<span><b>Warning</b></span>"
@@ -59,6 +60,28 @@ msgid ""
 "href=\"https://github.com/pardus/pardus-nvidia-installer\"> Pardus Github </"
 "a>"
 msgstr ""
+"Esta aplicação é desenvolvida e mantida pela equipa do Pardus para facilitar "
+"a instalação do controlador gráfico da Nvidia. Os controladores são obtidos "
+"a partir dos repositórios oficiais do Pardus e da Nvidia.\n"
+"\n"
+"<b>Fonte e utilização dos controladores</b>\n"
+"Embora esta seja um aplicação oficial do Pardus, os controladores gráficos "
+"em si são desenvolvidos pela Nvidia Corporation. O Pardus fornece esta "
+"ferramenta de instalação como uma conveniência para os nossos utilizadores, "
+"mas os controladores continuam a ser propriedade intelectual da Nvidia "
+"Corporation.\n"
+"\n"
+"<b>Isenção de responsabilidade:</b>\n"
+"Tenha em atenção que, embora nos esforcemos por assegurar um processo de "
+"instalação sem problemas, o Pardus não pode garantir o desempenho ou a "
+"compatibilidade dos controladores Nvidia com todas as configurações de "
+"hardware. Os utilizadores instalam estes controladores por sua própria conta "
+"e risco.\n"
+"\n"
+"<b>Comunicação de problemas:</b>\n"
+"Pode comunicar quaisquer problemas ou preocupações através do nosso "
+"repositório GitHub: <a href=\"https://github.com/pardus/pardus-nvidia-"
+"installer\"> GitHub do Pardus </a>"
 
 #: ui/ui.glade:177
 msgid ""
@@ -136,12 +159,11 @@ msgstr "Operação concluída com sucesso"
 
 #: src/std_opr.py:86
 msgid "Auth or cancellation error"
-msgstr ""
+msgstr "Erro de autenticação ou cancelamento"
 
 #: src/std_opr.py:88
-#, fuzzy
 msgid "An error occured"
-msgstr "Ocorreu um erro."
+msgstr "Ocorreu um erro"
 
 #, fuzzy
 #~ msgid ""

--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -1,7 +1,6 @@
 import gi
 import os
 import apt
-import signal
 import nvidia
 import std_opr
 import locale

--- a/src/nvidia.py
+++ b/src/nvidia.py
@@ -1,5 +1,4 @@
 import os
-from os.path import isfile
 import apt
 import json
 import shutil

--- a/src/package.py
+++ b/src/package.py
@@ -4,7 +4,6 @@ import apt
 import sys
 import subprocess
 import shutil
-import nvidia
 import apt_pkg
 
 apt_pkg.init_system()
@@ -20,6 +19,14 @@ nvidia_disable_gpu_path = "/var/cache/pni-disable-gpu"
 nvidia_src_file = "nvidia-drivers.list"
 dest = "/etc/apt/sources.list.d/nvidia-drivers.list"
 src_list = os.path.dirname(__file__) + "/../" + nvidia_src_file
+cuda_source = """
+if [ -d "/usr/local/cuda" ]; then
+    export PATH=/usr/local/cuda/bin:$PATH
+    export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+
+"""
+HOME = os.path.expanduser("~")
+bashrc_path = os.path.join(HOME, ".bashrc")
 
 
 def sys_source():
@@ -82,6 +89,14 @@ def install_nvidia(nv_drv):
         env={**os.environ},
     )
 
+    subprocess.call(
+        ["systemctl", "enable", "nvidia-suspend"],
+        env={**os.environ},
+    )
+
+    with open(bashrc_path, "a") as f:
+        f.write(cuda_source)
+
 
 def install_nouveau():
     subprocess.call(
@@ -90,7 +105,7 @@ def install_nouveau():
     )
 
 
-def toggle_driver(self):
+def toggle_driver():
     toggle_source_list()
     install_nvidia()
 

--- a/src/std_opr.py
+++ b/src/std_opr.py
@@ -1,6 +1,4 @@
-import os
 import gi
-import dbus
 import subprocess
 import locale
 
@@ -18,7 +16,7 @@ locale.textdomain(APPNAME_CODE)
 
 def start_prc(self, params):
     print(params)
-    pid, std_in, std_out, std_err = GLib.spawn_async(
+    pid, _, std_out, _ = GLib.spawn_async(
         params,
         flags=GLib.SpawnFlags.DO_NOT_REAP_CHILD,
         standard_output=True,


### PR DESCRIPTION
## Description
When the Nvidia driver is installed, it is not recognized by the system because CUDA is not sourced. Additionally, after the installation of the Nvidia driver, the computer does not fully enter sleep mode and wakes up again. To address this, the nvidia-suspend service has been activated.

- [ x ] New feature (non-breaking change which adds functionality)

## Checklist

- [ x ] My commits follow the commit standards of this project
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] My changes generate no new warnings
- [ x ] I have checked my code and corrected any misspellings
